### PR TITLE
BGP autoconfig with grpc

### DIFF
--- a/plugin/ipvlan/cli.go
+++ b/plugin/ipvlan/cli.go
@@ -10,6 +10,8 @@ var (
 	FlagMtu            = cli.IntFlag{Name: "mtu", Value: cliMTU, Usage: "MTU of the container interface (default: 1500)"}
 	FlagIpvlanEthIface = cli.StringFlag{Name: "host-interface", Value: ipVlanEthIface, Usage: "(required) interface that the container will be communicating outside of the docker host with"}
 	FlagRoutingManager = cli.StringFlag{Name: "routemng", Value: routingManager, Usage: "name of the routing manager name [gobgp]. (default: gobgp)"}
+	FlagServerAddr     = cli.StringFlag{Name: "serveraddr", Value: ServerAddr, Usage: "ID of the bgp router. (default: 127.0.0.1)"}
+	FlagBgpAs          = cli.StringFlag{Name: "as", Value: BgpAs, Usage: "AS number of bgp router. (default: 65000)"}
 )
 
 var (
@@ -20,4 +22,6 @@ var (
 	gatewayIP      = ""               // GW required for L2. increment network addr+1 if not defined
 	cliMTU         = 1500
 	routingManager = "gobgp"
+	ServerAddr     = "127.0.0.1"
+	BgpAs          = "65000"
 )

--- a/plugin/ipvlan/driver.go
+++ b/plugin/ipvlan/driver.go
@@ -122,12 +122,20 @@ func New(version string, ctx *cli.Context) (Driver, error) {
 		ipVlanMode = ipVlanL3Routing
 		containerGW = nil
 		managermode := ""
+		serveraddr := net.ParseIP("127.0.0.1")
+		as := "65000"
 		if ctx.String("routemng") != "" {
 			managermode = ctx.String("routemng")
 		}
+		if ctx.String("serveraddr") != "" {
+			serveraddr = net.ParseIP(ctx.String("serveraddr"))
+		}
+		if ctx.String("as") != "" {
+			as = ctx.String("as")
+		}
 
 		// Initialize Routing monitoring
-		go routing.InitRoutingMonitering(ipVlanEthIface, managermode)
+		go routing.InitRoutingMonitering(ipVlanEthIface, managermode, serveraddr, as)
 
 	default:
 		log.Fatalf("Invalid IPVlan mode supplied [ %s ]. IPVlan has two modes: [ %s ] or [%s ]", ctx.String("mode"), ipVlanL2, ipVlanL3)

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -39,6 +39,8 @@ func main() {
 		ipvlan.FlagSubnet,
 		ipvlan.FlagMtu,
 		ipvlan.FlagRoutingManager,
+		ipvlan.FlagServerAddr,
+		ipvlan.FlagBgpAs,
 	}
 	app.Before = initEnv
 	app.Action = Run

--- a/plugin/routing/route-interface.go
+++ b/plugin/routing/route-interface.go
@@ -14,14 +14,14 @@ type RoutingInterface interface {
 	WithdrawRoute(localPrefix *net.IPNet) error
 }
 
-func InitRoutingMonitering(masterIface string, managermode string) {
+func InitRoutingMonitering(masterIface string, managermode string, serveraddr net.IP, as string) {
 	switch managermode {
 	case "gobgp":
 		log.Infof("Routing manager is %s", managermode)
-		routemanager = gobgp.NewBgpRouteManager(masterIface, net.ParseIP("127.0.0.1"))
+		routemanager = gobgp.NewBgpRouteManager(masterIface, serveraddr, as)
 	default:
 		log.Infof("Default Routing manager: Gobgp")
-		routemanager = gobgp.NewBgpRouteManager(masterIface, net.ParseIP("127.0.0.1"))
+		routemanager = gobgp.NewBgpRouteManager(masterIface, serveraddr, as)
 	}
 	error := routemanager.StartMonitoring()
 	if error != nil {


### PR DESCRIPTION
Latest version GoBGP is able to start with no config file. Set global config and add peer with grpc api while running.
This patch enable to share Router ID and AS number with libkv ( supported backend is only consul now  ) and to use multi host l3 mode with no config file.
# Get start
### Requirement:
- docker : git commit:   1e514de (--default-network option exist)
- libnetwork : git commit ec95763dee6cd056308f4ec4cef395feb112a288 or older (as ipvlan driver uses ipallocator)
- GoBGP(latest) : git commit 340266259790af559a64d50383a8923ae2d8d407
- consul
### Run consul first

```
$consul agent -server -bootstrap -data-dir /tmp/consul -bind=<host IP>
$consul join <consul master ip>
```
### Build and Run GOBGP with no config file

```
$cd GOPATH/src/github.com/osrg/gobgp/gobgpd
$go build -o gobgpd main.go
$sudo ./gobgpd
```
### Run docker

```
$sudo docker daemon -H unix:// --default-network=ipvlan:ipvlan-l3 --kv-store=consul:localhost:8500
```
### Run ipvlan driver

```
$go run main.go --host-interface=eth0 -d --mode=l3routing --ipvlan-subnet=10.1.1.0/24 --routemng=gobgp --serveraddr=<host IP> ( *optional --as=<as number> )
```

Then ipvlan driver sets router ID ( =serveraddr ) and AS number to gobgp. router IDs and its as number share each host and add to its peer.
You don't need to write any config files! Happy!
But this is only poc, I think it is better to use host discovery of libnetwork for share host ip addresses and trigger of add peer.

Signed-off-by: YujiOshima yuji.oshima0x3fd@gmail.com
