### PR TITLE
Updated the API to libnetwork/docker v1.9

### DIFF
--- a/plugin/routing/gobgp/gobgp_routemanager.go
+++ b/plugin/routing/gobgp/gobgp_routemanager.go
@@ -151,7 +151,8 @@ func (b *BgpRouteManager) StartMonitoring() error {
 					neighborAS, _ := strconv.ParseUint(string(neighbor.Value), 10, 32)
 					log.Debugf("BGP neighbor add %s", neighboraddr)
 					peer := &api.Peer{
-						NighborAddress: neighboraddr,
+						// TODO: Debug Unresolved in Gobgp API master
+						// NighborAddress: neighboraddr,
 						Conf: &api.PeerConf{
 							NeighborAddress: neighboraddr,
 							PeerAs:          uint32(neighborAS),


### PR DESCRIPTION
- This updates the plugin to the final changes to the libnetwork APIs as it left experimental with v1.9 released 2 weeks ago. There are some gaps that probably wont get fixed since macvlan/ipvlan support will be native in libnetwork so we can do kewler stuff then ports with plugins so stay tuned.
- Had to comment out a field on line 154 of gobgp_routemanager.go to get a compile from the gobgp latest master. Not sure how that integration works so my bad if it broke anything.
- A native driver docker binary and example is at http://git.io/vCwvi the src is in a branch in my repo.
