### PR TITLE
Added libnetwork option flag support

### DIFF
--- a/plugin/ipvlan/cli.go
+++ b/plugin/ipvlan/cli.go
@@ -3,7 +3,8 @@ package ipvlan
 import "github.com/codegangsta/cli"
 
 var (
-	//  Exported user CLI flag config options
+	// Exported user CLI flag config options
+	// Most of these are depricated with libnetwork now accepting --options
 	FlagIPVlanMode     = cli.StringFlag{Name: "mode", Value: ipVlanMode, Usage: "name of the ipvlan mode [l2|l3]. (default: l2)"}
 	FlagGateway        = cli.StringFlag{Name: "gateway", Value: "", Usage: "IP of the default gateway (defaultL2 mode: first usable address of a subnet. Subnet 192.168.1.0/24 would mean the container gateway to 192.168.1.1)"}
 	FlagSubnet         = cli.StringFlag{Name: "ipvlan-subnet", Value: defaultSubnet, Usage: "subnet for the containers (l2 mode: 192.168.1.0/24)"}

--- a/plugin/ipvlan/state.go
+++ b/plugin/ipvlan/state.go
@@ -1,0 +1,101 @@
+package ipvlan
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/libnetwork/types"
+)
+
+type network struct {
+	id        string
+	endpoints endpointTable
+	driver    *driver
+	ifaceOpt  string
+	modeOpt   string
+	sync.Mutex
+}
+
+type networkTable map[string]*network
+
+func (d *driver) getNetwork(id string) (*network, error) {
+	d.Lock()
+	defer d.Unlock()
+
+	if id == "" {
+		return nil, types.BadRequestErrorf("invalid network id: %s", id)
+	}
+
+	if nw, ok := d.networks[id]; ok {
+		return nw, nil
+	}
+
+	return nil, types.NotFoundErrorf("network not found: %s", id)
+}
+
+func (n *network) endpoint(eid string) *endpoint {
+	n.Lock()
+	defer n.Unlock()
+
+	return n.endpoints[eid]
+}
+
+func (n *network) addEndpoint(ep *endpoint) {
+	n.Lock()
+	n.endpoints[ep.id] = ep
+	n.Unlock()
+}
+
+func (n *network) deleteEndpoint(eid string) {
+	n.Lock()
+	delete(n.endpoints, eid)
+	n.Unlock()
+}
+
+func (n *network) getEndpoint(eid string) (*endpoint, error) {
+	n.Lock()
+	defer n.Unlock()
+	if eid == "" {
+		return nil, fmt.Errorf("endpoint id %s not found", eid)
+	}
+	if ep, ok := n.endpoints[eid]; ok {
+		return ep, nil
+	}
+	return nil, nil
+}
+
+func (d *driver) network(nid string) *network {
+	d.Lock()
+	networks := d.networks
+	d.Unlock()
+	n, ok := networks[nid]
+	if !ok {
+		logrus.Errorf("network id %s not found", nid)
+	}
+	return n
+}
+
+func (d *driver) addNetwork(n *network) {
+	d.Lock()
+	d.networks[n.id] = n
+	d.Unlock()
+}
+
+func (d *driver) delNetwork(nid string) {
+	d.Lock()
+	delete(d.networks, nid)
+	d.Unlock()
+}
+
+// Safely return a slice of existng networks
+func (d *driver) getNetworks() []*network {
+	d.Lock()
+	defer d.Unlock()
+
+	ls := make([]*network, 0, len(d.networks))
+	for _, nw := range d.networks {
+		ls = append(ls, nw)
+	}
+	return ls
+}

--- a/plugin/ipvlan/utils.go
+++ b/plugin/ipvlan/utils.go
@@ -2,7 +2,6 @@ package ipvlan
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 
 	log "github.com/Sirupsen/logrus"
@@ -15,14 +14,6 @@ func makeMac(ip net.IP) string {
 	hw[1] = 0x42
 	copy(hw[2:], ip.To4())
 	return hw.String()
-}
-
-func readResolvConf() ([]byte, error) {
-	resolv, err := ioutil.ReadFile("/etc/resolv.conf")
-	if err != nil {
-		return nil, err
-	}
-	return resolv, nil
 }
 
 // Return the IPv4 address of a network interface


### PR DESCRIPTION
- libnetwork opt support no longer requires flags to the driver.
- driver flags are still supported until l3 and l3routing modes are
  validated.
- updated readme.
